### PR TITLE
PackageChecker minor cleanups and more detailed description

### DIFF
--- a/Orchestration/PackageChecker.ps1
+++ b/Orchestration/PackageChecker.ps1
@@ -1,27 +1,30 @@
-﻿#Package Checker - Check for new versions of each app defined
+﻿# Package Checker - For each package definition in 'packages' check if new dist avalable, if so create a package
+# Cases:
+# (1) Package definition is a folder with checkpackage.ps1 script
+# (2) Package definition is a folder with a Manifest.xml definition
+# (3) Package definition is a standalone PACKAGE.ps1 script
+
 [CmdLetBinding(SupportsShouldProcess)]
 Param()
 #Start-Transcript -Path \\usc.internal\usc\appdev\General\Logs\AutoSequencer.log -Append
-$Working = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+$Working = $PSScriptRoot
 
 #$DefinedApps='VSCode.ps1','Git','Python'
 Get-ChildItem -Path (Join-Path -Path $Working -ChildPath "Packages") | ForEach-Object {
-    [Array]$DefinedApps += Join-Path -Path "Packages" -ChildPath $_.Name
-}
+    $DefinedApp = $_.Name
+    $DefinedAppPath = $_.FullName
 
-ForEach ($DefinedApp in $DefinedApps) {
-    Write-Verbose "Running test for $DefinedApp at $(Get-Date)" -Verbose
-    $DefinedAppPath = Join-Path -Path $Working -ChildPath $DefinedApp
+    Write-Verbose "Checking for updated version of app $DefinedApp at $(Get-Date)" -Verbose
     If ((Get-Item $DefinedAppPath).PSIsContainer) {
-        $CheckPackage = Join-Path -Path $DefinedAppPath -ChildPath CheckPackage.ps1
-        $Manifest = Join-Path -Path $DefinedAppPath -ChildPath Manifest.xml
+        $CheckPackage = Join-Path -Path $DefinedAppPath -ChildPath "CheckPackage.ps1"
+        $Manifest = Join-Path -Path $DefinedAppPath -ChildPath "Manifest.xml"
         If (Test-Path $CheckPackage) {
             & "$CheckPackage" -Verbose
         } elseif (Test-Path $Manifest) {
             & "$Working\Functions\Start-ManifestProcess.ps1" -Manifest $Manifest -Verbose
         }
     } else {
-        & "$Working\$DefinedApp" -Verbose
+        & "$DefinedAppPath" -Verbose
     }
 }
 


### PR DESCRIPTION
Packagechecker
- Slight simplification and perform work in a single loop instead of two
- Amended initial comment to make the function intention clearer
- Note in this patched version $definedapp values are no longer prefixed by the 'Packages/'